### PR TITLE
Implement simple Franklin diary web app

### DIFF
--- a/franklin-diary/README.md
+++ b/franklin-diary/README.md
@@ -1,0 +1,28 @@
+# Franklin Diary
+
+A simple Franklin-style diary web application with Google OAuth login. Diary entries are stored on the server side so you can access them from any device. The calendar highlights days with existing entries.
+
+## Setup
+
+1. Install dependencies (requires Node.js):
+
+```bash
+npm install
+```
+
+2. Configure Google OAuth credentials. Create a project in the Google Developer Console and set the environment variables:
+
+```bash
+export GOOGLE_CLIENT_ID=your_client_id
+export GOOGLE_CLIENT_SECRET=your_client_secret
+```
+
+3. Start the server:
+
+```bash
+npm start
+```
+
+The app runs on `http://localhost:3000`. Browse to that address and log in with Google to start using the diary.
+
+Data is saved in `data.json` in the project directory.

--- a/franklin-diary/package.json
+++ b/franklin-diary/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "franklin-diary",
+  "version": "1.0.0",
+  "description": "Simple Franklin-style diary with Google login",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "body-parser": "^1.20.1",
+    "passport": "^0.6.0",
+    "passport-google-oauth20": "^2.0.0"
+  }
+}

--- a/franklin-diary/public/index.html
+++ b/franklin-diary/public/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Franklin Diary</title>
+<style>
+  body { font-family: Arial, sans-serif; }
+  #calendar { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
+  #calendar div { padding: 8px; border: 1px solid #ccc; text-align: center; cursor: pointer; }
+  #calendar div.has-entry { background-color: #ffd; font-weight: bold; }
+  textarea { width: 100%; height: 100px; }
+</style>
+</head>
+<body>
+<h1>Franklin Diary</h1>
+<div id="calendar"></div>
+<div id="entry" style="display:none;">
+  <h3 id="entry-date"></h3>
+  <textarea id="entry-text"></textarea><br>
+  <button id="save-btn">Save</button>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/franklin-diary/public/script.js
+++ b/franklin-diary/public/script.js
@@ -1,0 +1,58 @@
+const calendarEl = document.getElementById('calendar');
+const entryEl = document.getElementById('entry');
+const entryDateEl = document.getElementById('entry-date');
+const entryTextEl = document.getElementById('entry-text');
+const saveBtn = document.getElementById('save-btn');
+
+let entries = {};
+let currentDate = new Date();
+
+function loadEntries() {
+  fetch('/api/entries').then(r => r.json()).then(data => {
+    entries = data;
+    renderCalendar();
+  }).catch(() => {
+    calendarEl.innerHTML = '<p>Please <a href="/login">log in</a>.</p>';
+  });
+}
+
+function renderCalendar() {
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  calendarEl.innerHTML = '';
+  for (let i = 0; i < firstDay; i++) {
+    const div = document.createElement('div');
+    calendarEl.appendChild(div);
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${year}-${String(month+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+    const div = document.createElement('div');
+    div.textContent = d;
+    if (entries[dateStr]) div.classList.add('has-entry');
+    div.addEventListener('click', () => showEntry(dateStr));
+    calendarEl.appendChild(div);
+  }
+}
+
+function showEntry(dateStr) {
+  entryDateEl.textContent = dateStr;
+  entryTextEl.value = entries[dateStr] || '';
+  entryEl.style.display = 'block';
+  saveBtn.onclick = () => saveEntry(dateStr);
+}
+
+function saveEntry(dateStr) {
+  const text = entryTextEl.value;
+  fetch('/api/entries', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ date: dateStr, text })
+  }).then(() => {
+    entries[dateStr] = text;
+    renderCalendar();
+  });
+}
+
+loadEntries();

--- a/franklin-diary/server.js
+++ b/franklin-diary/server.js
@@ -1,0 +1,84 @@
+const express = require('express');
+const session = require('express-session');
+const bodyParser = require('body-parser');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const DATA_FILE = path.join(__dirname, 'data.json');
+
+app.use(bodyParser.json());
+app.use(session({ secret: 'secret', resave: false, saveUninitialized: true }));
+app.use(passport.initialize());
+app.use(passport.session());
+
+// simple in-file storage
+let store = {};
+if (fs.existsSync(DATA_FILE)) {
+  try {
+    store = JSON.parse(fs.readFileSync(DATA_FILE, 'utf-8'));
+  } catch (e) {
+    console.error('Failed to load data:', e);
+  }
+}
+
+function saveStore() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(store, null, 2));
+}
+
+passport.use(new GoogleStrategy({
+  clientID: process.env.GOOGLE_CLIENT_ID || 'GOOGLE_CLIENT_ID',
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'GOOGLE_CLIENT_SECRET',
+  callbackURL: '/auth/google/callback'
+}, (accessToken, refreshToken, profile, cb) => {
+  return cb(null, { id: profile.id, displayName: profile.displayName });
+}));
+
+passport.serializeUser((user, cb) => cb(null, user));
+passport.deserializeUser((obj, cb) => cb(null, obj));
+
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) return next();
+  res.redirect('/login');
+}
+
+app.get('/auth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+app.get('/auth/google/callback',
+  passport.authenticate('google', { failureRedirect: '/login' }),
+  (req, res) => {
+    res.redirect('/');
+  }
+);
+
+app.get('/login', (req, res) => {
+  res.send('<a href="/auth/google">Login with Google</a>');
+});
+
+app.get('/logout', (req, res) => {
+  req.logout(() => {});
+  res.redirect('/login');
+});
+
+app.use(express.static('public'));
+
+app.get('/api/entries', ensureAuthenticated, (req, res) => {
+  const userEntries = store[req.user.id] || {};
+  res.json(userEntries);
+});
+
+app.post('/api/entries', ensureAuthenticated, (req, res) => {
+  const { date, text } = req.body;
+  if (!date || !text) return res.status(400).json({ error: 'date and text required' });
+  if (!store[req.user.id]) store[req.user.id] = {};
+  store[req.user.id][date] = text;
+  saveStore();
+  res.json({ success: true });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a basic Express server with Google OAuth authentication
- implement API endpoints for diary entries saved on the server
- create a small front-end with a grid calendar and entry editor
- include setup instructions in README

## Testing
- `npm install` *(fails: no internet access)*


------
https://chatgpt.com/codex/tasks/task_e_6860c8a6b43c83268ce95bc02aa68a50